### PR TITLE
Update README.md to cover mismatched expected master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Before installing the gem, ensure both your node and [yarn](https://yarnpkg.com/
 
 ```ruby
 # Gemfile
-gem "railsui", github: "getrailsui/railsui"
+gem "railsui", github: "getrailsui/railsui", branch: "main"
 ```
 
 ```bash


### PR DESCRIPTION
When I tried to run the install with the usual bundle import, I got an error stating that bundle expected "master" branch, but it couldn't be found.

After adding "branch : 'main'" to the import, the installation worked successfully.

<img width="1408" alt="Screenshot 2023-08-05 at 2 59 56 AM" src="https://github.com/getrailsui/railsui/assets/1866816/e0005aa3-2833-45a1-b1a2-e8276147ec6c">
