### PR TITLE
Add jsbundling-rails and cssbundling-rails as dependencies

### DIFF
--- a/railsui.gemspec
+++ b/railsui.gemspec
@@ -32,4 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'psych'
   spec.add_dependency 'name_of_person'
   spec.add_dependency 'meta-tags'
+  spec.add_dependency 'cssbundling-rails'
+  spec.add_dependency 'jsbundling-rails'
 end


### PR DESCRIPTION
When pushing to a production environment (after testing), there's no precomplication step without the help from the cssbundling-rails and jsbundling-rails gem in place. I mistakenly removed them as dependencies before testing them in a production-level environment. 