### PR TITLE
Move pages to nav and singular page

### DIFF
--- a/app/controllers/railsui/pages_controller.rb
+++ b/app/controllers/railsui/pages_controller.rb
@@ -1,0 +1,11 @@
+require_dependency "railsui/application_controller"
+
+module Railsui
+  class PagesController < ApplicationController
+    layout "railsui/fullwidth"
+
+    def show
+      @theme_pages = Railsui::Pages.installed_pages
+    end
+  end
+end

--- a/app/views/railsui/pages/show.html.erb
+++ b/app/views/railsui/pages/show.html.erb
@@ -1,0 +1,43 @@
+<div class="py-8" data-controller="railsui-pages">
+  <%= heading text: "Pages", id: "pages", tag: "h2", class: "font-bold text-3xl tracking-tight mb-6" %>
+
+  <div class="prose prose-neutra dark:prose-invert mb-6">
+    <p>Prototype rapidly with ready-made pages that look great with the <%= theme_name.humanize %> theme.</p>
+  </div>
+
+  <div class="mb-10">
+    <div class="divide-y divide-neutral-200/80 dark:divide-neutral-700/80 py-2.5">
+      <% @theme_pages.each do |page, details| %>
+        <div class="flex flex-wrap items-start justify-between py-3">
+          <%= render "railsui/admin/fields/page", page: page, details: details %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="flex items-start gap-5 py-5">
+    <div class="flex-shrink-0">
+      <div class="size-10 rounded-full flex items-center justify-center bg-neutral-50 dark:bg-neutral-800/80">
+        <%= icon "document-plus", class: "size-5 text-neutral-600 dark:text-neutral-400" %>
+      </div>
+    </div>
+
+    <div class="prose prose-sm max-w-full prose-neutral dark:prose-invert">
+      <h4>Adding pages</h4>
+      <p>Installed pages are found inside the <code>app/views/rui/pages</code> folder.</p>
+    </div>
+  </div>
+
+  <div class="flex items-start gap-5 py-5">
+    <div class="flex-shrink-0">
+      <div class="size-10 rounded-full flex items-center justify-center bg-neutral-50 dark:bg-neutral-800/80">
+        <%= icon "hand-thumb-up", class: "size-5 text-neutral-600 dark:text-neutral-400" %>
+      </div>
+    </div>
+
+    <div class="prose prose-sm max-w-full prose-neutral dark:prose-invert">
+      <h4>Best practices</h4>
+      <p>Pages are a starting point. Copy them to other views you're working on and make changes there as opposed to directly inside the <code>app/views/rui/pages</code> directory. Treat this directory as read-only. <strong>Changing your Rails UI configuration will override the directory</strong>.</p>
+    </div>
+  </div>
+</div>

--- a/app/views/railsui/shared/_global_nav.html.erb
+++ b/app/views/railsui/shared/_global_nav.html.erb
@@ -30,14 +30,14 @@
 
           <% if Railsui.config.theme.present? %>
             <a href="#color" data-action="click->railsui-smooth#scroll" class="pl-1 pr-2 py-1.5 block relative hover:transition hover:duration-200 hover:ease-in-out dark:focus:text-white hover:bg-neutral-50/90 rounded transition dark:text-neutral-200 dark:hover:bg-neutral-800/70 dark:hover:text-white group">Color</a>
-
-            <a href="#pages" data-action="click->railsui-smooth#scroll" class="pl-1 pr-2 py-1.5 block relative hover:transition hover:duration-200 hover:ease-in-out dark:focus:text-white hover:bg-neutral-50/90 rounded transition dark:text-neutral-200 dark:hover:bg-neutral-800/70 dark:hover:text-white group">Pages</a>
           <% end %>
         </div>
       <% end %>
 
       <% if Railsui.config.theme.present? %>
         <%= render "railsui/shared/global_nav_item", path: systems_path, icon: "cube", label:"Components" %>
+
+        <%= render "railsui/shared/global_nav_item", path: pages_url, icon: "window", label: "Pages" %>
 
         <% if params[:controller].include?('systems') %>
           <%= render "railsui/shared/system_nav" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Railsui::Engine.routes.draw do
   resource :routes, only: :show
   resources :mailers, only: [:index, :show]
   get :delete_page, to: "configurations#delete_page"
+  get :pages, to: "pages#show"
 
   namespace :systems do
     get :authentication


### PR DESCRIPTION
Cleaning up the navigation to move pages outside of the configuration namespace. Pages are installed by default now and are relative to a selected theme.