### PR TITLE
Migrate to tailwindcss-rails gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,0 @@
-# Changelog
-
-## [1.0.0] - 2023-03-29
-
-- Initial release
-
-## [1.0.1] - 2023-05-23
-
-Removes cssbundling-rails and jsbundling-rails gems from being gem dependencies. We bring necessary logic under the hood and reduce errors during install.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
       psych
       rails (>= 7.0)
       railsui_icon
+      tailwindcss-rails
 
 GEM
   remote: https://rubygems.org/
@@ -222,6 +223,10 @@ GEM
       railties (>= 6.0.0)
     stringio (3.1.1)
     strscan (3.1.0)
+    tailwindcss-rails (4.0.0)
+      railties (>= 7.0.0)
+      tailwindcss-ruby (~> 4.0)
+    tailwindcss-ruby (4.0.6-arm64-darwin)
     thor (1.3.2)
     timeout (0.4.1)
     tzinfo (2.0.6)

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,0 +1,139 @@
+# Migration Guide: Rails UI to tailwindcss-rails
+
+This guide explains the changes made to Rails UI to use `tailwindcss-rails` instead of the previous CSS bundling approach.
+
+## What Changed
+
+### Before (v3.1.5)
+- Required `cssbundling-rails` and `jsbundling-rails`
+- Needed `rails new app_name -c tailwind -j esbuild` for new apps
+- Used `yarn build:css` for CSS compilation
+- Required manual setup of Tailwind CSS
+
+### After (v3.1.6+)
+- Uses `tailwindcss-rails` as the primary CSS management solution
+- Simplified installation: `rails new app_name -j esbuild`
+- Automatic Tailwind CSS installation during Rails UI setup
+- Uses `rails tailwindcss:build` and `rails tailwindcss:watch` for CSS management
+
+## Installation Changes
+
+### New Applications
+
+**Before:**
+```bash
+rails new app_name -c tailwind -j esbuild
+gem "railsui"
+bundle install
+rails railsui:install
+```
+
+**After:**
+```bash
+rails new app_name
+gem "railsui"
+bundle install
+rails railsui:install
+```
+
+### Existing Applications
+
+**Before:**
+```bash
+./bin/bundle add cssbundling-rails
+./bin/rails css:install:tailwind
+./bin/bundle add jsbundling-rails
+./bin/rails javascript:install:esbuild
+gem "railsui"
+bundle install
+rails railsui:install
+```
+
+**After:**
+```bash
+gem "railsui"
+bundle install
+rails railsui:install
+```
+
+## Development Workflow
+
+### Before
+```bash
+bin/dev  # Uses Procfile.dev with cssbundling-rails
+```
+
+### After
+```bash
+bin/dev  # Uses Procfile.dev with tailwindcss-rails
+```
+
+The new Procfile.dev includes:
+```
+web: bin/rails server -p 3000
+css: bin/rails tailwindcss:watch
+js: yarn build --watch
+```
+
+## File Structure Changes
+
+### CSS Files
+- **Before:** `app/assets/stylesheets/application.tailwind.css`
+- **After:** `app/assets/tailwind/application.css`
+
+## Benefits
+
+1. **Simplified Installation:** No need for `-c tailwind` flag anymore. Less package manager headaches.
+2. **Better Integration:** Native Rails integration with `tailwindcss-rails`
+3. **Reduced Dependencies:** Fewer gems to manage
+4. **Improved Performance:** More efficient CSS compilation
+5. **Better Development Experience:** Integrated watch mode with Rails server
+
+## Migration Steps
+
+If you're upgrading from a previous version:
+
+1. Update your Gemfile:
+   ```ruby
+   gem "railsui"
+   ```
+
+2. Run bundle update:
+   ```bash
+   bundle update railsui
+   ```
+
+3. Reinstall Rails UI:
+   ```bash
+   rails railsui:install
+   ```
+
+4. Update your development workflow:
+   - Use `bin/dev` for development
+   - CSS changes are automatically watched
+   - No manual CSS compilation needed
+
+## Troubleshooting
+
+### If you see CSS compilation errors:
+1. Make sure `tailwindcss-rails` is installed. Rails UI should add it for you if not.
+2. Run `rails tailwindcss:install` if needed (optional)
+3. Check that `app/assets/tailwind/application.css` exists
+
+### If you see JavaScript errors:
+1. Make sure you have a JavaScript bundler installed
+2. Run `rails javascript:install:esbuild` (or your preferred bundler)
+3. Check that your `package.json` has the correct build scripts
+
+### If the development server doesn't start:
+1. Make sure `Procfile.dev` exists and is correct
+2. Check that all dependencies are installed
+3. Try running `bin/rails server` and `bin/rails tailwindcss:watch` separately
+
+## Support
+
+If you encounter any issues during migration, please:
+
+1. Check the [Rails UI documentation](https://railsui.com/docs)
+2. Review the [tailwindcss-rails documentation](https://github.com/rails/tailwindcss-rails)
+3. Open an issue on the [Rails UI GitHub repository](https://github.com/getrailsui/railsui)

--- a/README.md
+++ b/README.md
@@ -20,43 +20,37 @@ You must already have node and yarn installed on your system. You will also need
 
 ### New applications
 
-The easiest install is on new Rails apps with options passed like so. For new apps, use the `-c tailwind` flag to install it.
+The easiest install is on new Rails apps. Rails UI now uses `tailwindcss-rails` for CSS management, which is automatically installed when you run the Rails UI installer.
 
 ```bash
-rails new app_name -c tailwind -j esbuild
+rails new app_name -j esbuild
 ```
-
-It's recommended to use the `-j` flag to one of the bundling solutions from the [`jsbundling-rails`](https://github.com/rails/jsbundling-rails) gem (bun, esbuild rollup, webpack) for max compatibility.
-
-Support for [importmaps](https://github.com/rails/importmap-rails) or [propshaft](https://github.com/rails/propshaft) is untested at this time.
 
 ### Existing applications
 
-#### CSS
+Rails UI now uses `tailwindcss-rails` for CSS management, which provides a simpler and more integrated approach to Tailwind CSS in Rails applications.
 
-For an existing app you need to first install Tailwind if you haven't. If you are using another CSS framework, like Bootstrap, remove that first for best results.
-
-```bash
-./bin/bundle add cssbundling-rails
-./bin/rails css:install:tailwind
-```
-
-Note: There are several ways to approach adding Tailwind CSS support. We find the easiest way is using [cssbundling-rails](https://github.com/rails/cssbundling-rails) gem for max control. If you were to scaffold a new rails application, this gem is the one used when passing `-c` or `-css`.
-
-Adding Tailwind CSS to an existing app _may_ result in CSS class name conflicts. We've done our best to make it integrate with your existing setup but there's always a chance.
+If you're migrating from an existing setup, Rails UI will automatically install `tailwindcss-rails` during the installation process.
 
 #### JavaScript
 
-Rails UI works best combined with the [jsbundling-rails](https://github.com/rails/jsbundling-rails) gem.
-
-When ready, install jsbundling-rails using the gem and the installer task. Choose the build tool you prefer.
+Rails UI works best with JavaScript bundling. You can use any of the supported bundling solutions:
 
 ```bash
-./bin/bundle add jsbundling-rails
-./bin/rails javascript:install:[bun|esbuild|rollup|webpack]
+# For esbuild (recommended)
+./bin/rails javascript:install:esbuild
+
+# For webpack
+./bin/rails javascript:install:webpack
+
+# For rollup
+./bin/rails javascript:install:rollup
+
+# For bun
+./bin/rails javascript:install:bun
 ```
 
-Most of the JavaScript used in Rails UI is based on Stimulus.js. This code can likely work fine alongside something like importmaps or propshaft but we have not tested this theory just yet.
+Most of the JavaScript used in Rails UI is based on Stimulus.js and will work with any of these bundling solutions.
 
 ## Installation
 
@@ -75,7 +69,7 @@ bundle install
 
 The gem includes several tasks and generators. Run the `install` task to kick things off.
 
-This task is responsible for setting the foundation for Rails UI, which includes assets, themes, theme-driven pages, and more.
+This task is responsible for setting the foundation for Rails UI, which includes assets, themes, theme-driven pages, and more. It will automatically install `tailwindcss-rails` if it's not already present.
 
 The default theme for Rails UI is [Hound](https://railsui.com/themes/hound). It will install when you install Rails UI. You can change it any time.
 
@@ -117,7 +111,7 @@ After installing Rails UI and choosing a theme you'll find a collection of compo
 
 ### Color
 
-Each theme comes with a custom color palette built on top of the default Tailwind CSS v4 color palette. We've added two new colors for you to use in your app using Tailwind CSS classes called `primary` and `secondary`. You can change those colors any time in `app/assets/stylesheets/railsui/theme.css`.
+Each theme comes with a custom color palette built on top of the default Tailwind CSS v4 color palette. We've added two new colors for you to use in your app using Tailwind CSS classes called `primary` and `secondary`. You can change those colors any time in `app/assets/stylesheets/railsui/theme.css` (which gets imported into `app/assets/tailwind/application.css`).
 
 ### Icons
 

--- a/app/views/layouts/railsui/application.html.erb
+++ b/app/views/layouts/railsui/application.html.erb
@@ -17,7 +17,7 @@
     <%= javascript_include_tag "railsui/application" %>
     <%= javascript_include_tag "https://unpkg.com/alpinejs@3.10.3/dist/cdn.min.js", defer: true %>
 
-    <%= stylesheet_link_tag "application", "railsui/railsui" %>
+    <%= stylesheet_link_tag "tailwind", "railsui/railsui" %>
 
     <link rel="stylesheet" href="https://unpkg.com/tippy.js@6/dist/tippy.css" />
 
@@ -35,6 +35,7 @@
   <body class="relative antialiased font-normal leading-normal railsui text-neutral-800 lg:h-screen selection:bg-neutral-300/20 selection:text-neutral-900 dark:selection:text-white dark:bg-neutral-900 dark:text-neutral-50" data-controller="railsui-toggle railsui-scroll railsui-smooth railsui-scroll-spy" data-railsui-scroll-spy-active-class-value="text-neutral-900 hover:text-neutral-950 dark:hover:text-neutral-200 dark:text-white dark:hover:text-white truncate"
       data-railsui-scroll-spy-inactive-class-value="text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-white truncate">
     <%= render "railsui/shared/flash_messages" %>
+
     <div class="flex md:flex-row flex-col items-start justify-between md:h-[calc(100vh-2px)] overflow-x-clip relative">
 
       <%= image_tag "blur.png", class: "absolute -top-[500px] -right-[500px] opacity-[0.02] dark:opacity-5 z-0" %>

--- a/app/views/layouts/railsui/fullwidth.html.erb
+++ b/app/views/layouts/railsui/fullwidth.html.erb
@@ -17,14 +17,12 @@
     <%= javascript_include_tag "railsui/application" %>
     <%= javascript_include_tag "https://unpkg.com/alpinejs@3.10.3/dist/cdn.min.js", defer: true %>
 
-    <%= stylesheet_link_tag "railsui/railsui", "application" %>
+    <%= stylesheet_link_tag "tailwind", "railsui/railsui" %>
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fira+Code&display=swap" rel="stylesheet">
 
-    <script src="https://unpkg.com/@tailwindcss/browser@4"></script>
-    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
 
     <link rel="stylesheet" href="https://unpkg.com/tippy.js@6/dist/tippy.css" />
 

--- a/app/views/layouts/railsui/landing.html.erb
+++ b/app/views/layouts/railsui/landing.html.erb
@@ -17,8 +17,7 @@
     <%= javascript_include_tag "railsui/application" %>
     <%= javascript_include_tag "https://unpkg.com/alpinejs@3.10.3/dist/cdn.min.js", defer: true %>
 
-    <%= stylesheet_link_tag "railsui/application" %>
-    <%= stylesheet_link_tag "application" %>
+    <%= stylesheet_link_tag "tailwind", "railsui/railsui" %>
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/app/views/layouts/railsui/routes.html.erb
+++ b/app/views/layouts/railsui/routes.html.erb
@@ -16,14 +16,12 @@
     <%= favicon_link_tag "favicon.svg" %>
     <%= javascript_include_tag "railsui/application" %>
     <%= javascript_include_tag "https://unpkg.com/alpinejs@3.10.3/dist/cdn.min.js", defer: true %>
-    <%= stylesheet_link_tag "railsui/application", "application" %>
+
+    <%= stylesheet_link_tag "tailwind", "railsui/railsui" %>
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fira+Code&display=swap" rel="stylesheet">
-
-    <script src="https://unpkg.com/@tailwindcss/browser@4"></script>
-    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
 
     <%= yield :head %>
   </head>

--- a/app/views/railsui/admin/fields/_color.html.erb
+++ b/app/views/railsui/admin/fields/_color.html.erb
@@ -9,7 +9,7 @@
 
     <% if File.exist?("#{Rails.root}/app/assets/stylesheets/railsui/theme.css") %>
       <h3 class="mb-0">theme.css</h3>
-      <p class="text-sm"><code class="text-neutral-400 font-normal">app/assets/stylesheets/railsui/theme.css</code></p>
+      <p class="text-sm"><code class="text-neutral-400 font-normal">app/assets/stylesheets/railsui/theme.css</code> (imported into <code>app/assets/tailwind/application.css</code>)</p>
 
       <div class="my-3 not-prose">
         <div data-controller="railsui-code" class="relative overflow-clip bg-gray-900 rounded-lg border-transparent  dark:border dark:border-neutral-700 selection:bg-neutral-300/90 selection:text-neutral-800 max-h-[400px] overflow-y-auto">
@@ -17,7 +17,7 @@
         </div>
       </div>
 
-      <p>The contents of the <code>app/assets/stylesheets/railsui/theme.css</code> file is displayed above for <strong><%= Railsui.config.theme.humanize %></strong>, your active theme. To customize this file, make a copy and update the <code>@import</code> path inside your main application CSS file to reference back to it. Use Tailwind's <%= link_to "theme variables guide", "https://tailwindcss.com/docs/theme", target: :_blank %> to extend this file.</p>
+      <p>The contents of the <code>app/assets/stylesheets/railsui/theme.css</code> file is displayed above for <strong><%= Railsui.config.theme.humanize %></strong>, your active theme. This file gets imported into <code>app/assets/tailwind/application.css</code>. To customize this file, make a copy and update the <code>@import</code> path inside your main application CSS file to reference back to it. Use Tailwind's <%= link_to "theme variables guide", "https://tailwindcss.com/docs/theme", target: :_blank %> to extend this file.</p>
 
       <p>I recommend <%= link_to "this tool", "https://uicolors.app/create?ref=railsui.com", target: :_blank %> for generating unique colors. Hex colors are acceptable. For a wider gamut you could reach for <%= link_to "okchl", "https://oklch.com", target: :_blank %> following in the footsteps of Tailwind CSS v4.</p>
 

--- a/app/views/railsui/admin/fields/_theme.html.erb
+++ b/app/views/railsui/admin/fields/_theme.html.erb
@@ -83,7 +83,7 @@
               </li>
             </ul>
             <li>
-              All CSS in <code>app/assets/stylesheets/railsui</code> is replaced with the newly chosen theme's CSS files and Tailwind CSS theme configurations.
+              All CSS in <code>app/assets/stylesheets/railsui</code> is replaced with the newly chosen theme's CSS files and Tailwind CSS theme configurations. These files get imported into <code>app/assets/tailwind/application.css</code>.
             </li>
           </ul>
         </div>

--- a/app/views/railsui/themes/hound/components/_toast.html.erb
+++ b/app/views/railsui/themes/hound/components/_toast.html.erb
@@ -36,7 +36,7 @@
 
 <% end %>
 <% content_for :css, flush: true do %>
-/* Add to app/assets/stylesheets/railsui/theme.css */
+/* Add to app/assets/stylesheets/railsui/theme.css (imported into app/assets/tailwind/application.css) */
 
 --animate-toast-from-right: toast-from-right 0.5s cubic-bezier(0.68, -0.55, 0.27, 1.55);
 --animate-toast-from-left: toast-from-left 0.5s cubic-bezier(0.68, -0.55, 0.27, 1.55);

--- a/app/views/railsui/themes/hound/content/typography/_fonts.html.erb
+++ b/app/views/railsui/themes/hound/content/typography/_fonts.html.erb
@@ -24,6 +24,6 @@
   </div>
 
   <div class="prose-sm prose-neutral dark:prose-invert">
-    <p><strong>Tip</strong>: To change fonts, you'll need to reference new them in both <code>app/views/rui/shared/_fonts.html.erb</code> and <code>app/assets/stylesheets/railsui/theme.css</code>.</p>
+    <p><strong>Tip</strong>: To change fonts, you'll need to reference new them in both <code>app/views/rui/shared/_fonts.html.erb</code> and <code>app/assets/stylesheets/railsui/theme.css</code> (which gets imported into <code>app/assets/tailwind/application.css</code>).</p>
   </div>
 </div>

--- a/app/views/railsui/themes/shepherd/components/_toast.html.erb
+++ b/app/views/railsui/themes/shepherd/components/_toast.html.erb
@@ -37,7 +37,7 @@
 
 <% end %>
 <% content_for :css, flush: true do %>
-/* Add to app/assets/stylesheets/railsui/theme.css */
+/* Add to app/assets/stylesheets/railsui/theme.css (imported into app/assets/tailwind/application.css) */
 
 --animate-toast-from-right: toast-from-right 0.5s cubic-bezier(0.68, -0.55, 0.27, 1.55);
 --animate-toast-from-left: toast-from-left 0.5s cubic-bezier(0.68, -0.55, 0.27, 1.55);

--- a/app/views/railsui/themes/shepherd/content/typography/_fonts.html.erb
+++ b/app/views/railsui/themes/shepherd/content/typography/_fonts.html.erb
@@ -24,6 +24,6 @@
   </div>
 
   <div class="prose-sm prose-neutral dark:prose-invert">
-    <p><strong>Tip</strong>: To change fonts, you'll need to reference new them in both <code>app/views/rui/shared/_fonts.html.erb</code> and <code>app/assets/stylesheets/railsui/theme.css</code>.</p>
+    <p><strong>Tip</strong>: To change fonts, you'll need to reference new them in both <code>app/views/rui/shared/_fonts.html.erb</code> and <code>app/assets/stylesheets/railsui/theme.css</code> (which gets imported into <code>app/assets/tailwind/application.css</code>).</p>
   </div>
 </div>

--- a/lib/generators/railsui/install/install_generator.rb
+++ b/lib/generators/railsui/install/install_generator.rb
@@ -16,7 +16,7 @@ module Railsui
         }
 
         config = Railsui::Configuration.new(configuration_params)
-        config.save
+        config.save(build_css: false)
       end
 
       def install_dependencies
@@ -24,48 +24,46 @@ module Railsui
 
         @theme = Railsui.config.theme
 
-        if File.exist?("#{Rails.root}/config/importmap.rb")
-          say "❌ Detected importmaps which is unfortunately not supported by Rails UI. For best results, please use another bundling solution from jsbundling-rails (i.e., esbuild, bun) before installing", :yellow
-        else
-          say "🔥 Installing default theme: #{@theme.humanize} 🐶. Don't worry, you can change this."
+        say "🔥 Installing default theme: #{@theme.humanize} 🐶. Don't worry, you can change this."
 
-          # Add engine routes
-          # Add a GUI for easier theme configuration
-          copy_railsui_routes
+        # Add engine routes
+        # Add a GUI for easier theme configuration
+        copy_railsui_routes
 
-          # gems railsui_icon and action_text
-          install_gems
+        # gems railsui_icon and action_text
+        install_gems
 
-          # mailers
-          update_application_helper
-          update_railsui_mailer_layout(@theme)
-          generate_sample_mailers(@theme)
+        # mailers
+        update_application_helper
+        update_railsui_mailer_layout(@theme)
+        generate_sample_mailers(@theme)
 
-          # rails ui deps
-          install_theme_dependencies(@theme)
+        # rails ui deps
+        install_theme_dependencies(@theme)
 
-          # assets
-          copy_theme_javascript(@theme)
-          copy_theme_stylesheets(@theme)
+        # assets
+        copy_theme_javascript(@theme)
+        copy_theme_stylesheets(@theme)
 
-          # view related
-          copy_railsui_head(@theme)
-          copy_railsui_launcher(@theme)
+        # view related
+        copy_railsui_head(@theme)
+        copy_railsui_launcher(@theme)
 
-          # cleanup
-          remove_action_text_defaults
+        # cleanup
+        remove_action_text_defaults
 
-          # Copy the pages related files.
-          copy_railsui_pages_routes
-          copy_railsui_page_controller(@theme)
-          copy_railsui_images(@theme)
-          copy_railsui_pages(@theme)
+        # Copy the pages related files.
+        copy_railsui_pages_routes
+        copy_railsui_page_controller(@theme)
+        copy_railsui_images(@theme)
+        copy_railsui_pages(@theme)
 
-          # migrate
-          rails_command "db:migrate"
+        # migrate
+        rails_command "db:migrate"
 
-          config.save
-say "
+        config.save(build_css: false)
+
+        say "
 MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
 MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
 MMMMMMMMMMMMMWXOxooodOXMMMMMMMMMMWXxxXMMMMMMMMMMMMMMMMMMMMMM
@@ -90,11 +88,10 @@ MMMMMMMMMNxldk0XNWMMMMMWNKkl,.  .lKWMMMMMXo. ,xNMMMMMMMMMMMM
 MMMMMMMMMWWMMMMMMMMMMMMMMMMMW0kkKWMMMMMMMMWKONMMMMMMMMMMMMMM
 MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
 "
-          say "✅ Install complete", :green
-          say "--"
-          say "🔥 Rails UI is now installed. You can access your configuration at /railsui"
-          say "Read documentation at https://railsui.com/docs for FAQs, guides, and more."
-        end
+        say "✅ Install complete", :green
+        say "--"
+        say "🔥 Rails UI is now installed. You can access your configuration at /railsui"
+        say "Read documentation at https://railsui.com/docs for FAQs, guides, and more."
       end
     end
   end

--- a/lib/generators/railsui/install/templates/Procfile.dev
+++ b/lib/generators/railsui/install/templates/Procfile.dev
@@ -1,0 +1,3 @@
+web: bin/rails server
+css: bin/rails tailwindcss:watch
+js: yarn build --watch

--- a/lib/generators/railsui/install/templates/themes/hound/stylesheets/railsui/tailwind.config.js
+++ b/lib/generators/railsui/install/templates/themes/hound/stylesheets/railsui/tailwind.config.js
@@ -5,6 +5,7 @@ const rails_ui_template_path = outputRailsUI.trim() + "/**/*.html.erb"
 
 module.exports = {
   content: [
+    // Rails UI gem files
     "./lib/generators/templates/**/*.html.erb.tt",
     "./config/initializers/railsui_icon.rb",
     rails_ui_path,

--- a/lib/generators/railsui/install/templates/themes/hound/views/layouts/rui/railsui.html.erb
+++ b/lib/generators/railsui/install/templates/themes/hound/views/layouts/rui/railsui.html.erb
@@ -12,7 +12,7 @@
 
     <%= yield :head %>
 
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
 
     <%= railsui_head %>

--- a/lib/generators/railsui/install/templates/themes/hound/views/layouts/rui/railsui_admin.html.erb
+++ b/lib/generators/railsui/install/templates/themes/hound/views/layouts/rui/railsui_admin.html.erb
@@ -12,7 +12,7 @@
 
     <%= yield :head %>
 
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
 
     <%= railsui_head %>

--- a/lib/generators/railsui/install/templates/themes/shepherd/views/layouts/rui/railsui.html.erb
+++ b/lib/generators/railsui/install/templates/themes/shepherd/views/layouts/rui/railsui.html.erb
@@ -12,7 +12,7 @@
 
     <%= yield :head %>
 
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
 
     <%= railsui_head %>

--- a/lib/generators/railsui/install/templates/themes/shepherd/views/layouts/rui/railsui_admin.html.erb
+++ b/lib/generators/railsui/install/templates/themes/shepherd/views/layouts/rui/railsui_admin.html.erb
@@ -12,7 +12,7 @@
 
     <%= yield :head %>
 
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
 
     <%= railsui_head %>

--- a/lib/railsui.rb
+++ b/lib/railsui.rb
@@ -26,15 +26,12 @@ module Railsui
   end
 
   def self.build_css
-    if File.exist?("#{Rails.root}/package.json")
-      package_json = JSON.parse(File.read("#{Rails.root}/package.json"))
-      if package_json["scripts"] && package_json["scripts"]["build:css"]
-        run_command "yarn build:css"
-      else
-        puts "'build:css' script not found in package.json, skipping"
-      end
-    else
-      puts "package.json not found in the application root, skipping"
+    # Use tailwindcss-rails build command
+    begin
+      run_command "rails tailwindcss:build"
+    rescue => e
+      puts "Warning: tailwindcss:build command not found. CSS may not be compiled."
+      puts "You may need to restart your Rails server or run 'rails tailwindcss:build' manually."
     end
   end
 

--- a/lib/railsui/configuration.rb
+++ b/lib/railsui/configuration.rb
@@ -62,7 +62,7 @@ module Railsui
       Rails.root.join("config", "railsui.yml")
     end
 
-    def save
+    def save(build_css: true)
       # Create config/railsui.yml
       File.write(self.class.config_path, to_yaml)
 
@@ -71,7 +71,7 @@ module Railsui
 
       sleep 1
 
-      Railsui.build_css
+      Railsui.build_css if build_css
     end
 
     def self.update(params={})

--- a/railsui.gemspec
+++ b/railsui.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'psych'
   spec.add_dependency 'meta-tags'
   spec.add_dependency 'railsui_icon'
+  spec.add_dependency 'tailwindcss-rails'
 end

--- a/test/test_railsui.rb
+++ b/test/test_railsui.rb
@@ -1,9 +1,19 @@
 # frozen_string_literal: true
 
-require "test_helper"
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "railsui/version"
+
+require "minitest/autorun"
 
 class TestRailsui < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::Railsui::VERSION
+  end
+
+  def test_that_it_includes_tailwindcss_rails_dependency
+    # Check that tailwindcss-rails is included in the gem dependencies
+    spec = Gem::Specification.find_by_name("railsui")
+    dependencies = spec.dependencies.map(&:name)
+    assert_includes dependencies, "tailwindcss-rails"
   end
 end


### PR DESCRIPTION
To avoid package manager schenanigans, it’s time we opt for the Ruby tailwindcss-rails and tailwindcss-ruby gems. They are just simpler and easier to integrate.