### PR TITLE
Fix missing icon

### DIFF
--- a/app/views/railsui/shared/_global_nav.html.erb
+++ b/app/views/railsui/shared/_global_nav.html.erb
@@ -14,7 +14,7 @@
       </div>
 
       <button role="toggle nav" class="md:hidden size-10 focus:ring-neutral-300/20 focus:ring-4 rounded-lg dark:focus:ring-neutral-600 flex items-center justify-center flex-shrink-0" data-action="click->railsui-toggle#toggle">
-        <%= icon "menu", custom_path: "/menu.svg", class: "stroke-current w-7 h-7 text-neutral-600 dark:text-neutral-300" %>
+        <%= icon "bars-3", class: "stroke-current w-7 h-7 text-neutral-600 dark:text-neutral-300" %>
       </button>
     </div>
 


### PR DESCRIPTION
Fix for #57. We were rendering a missing icon in the RailsUI global space, which caused logs to persist.