### PR TITLE
Remove redundant form_group helpers

### DIFF
--- a/app/views/railsui/themes/corgie/forms/_form_builder.html.erb
+++ b/app/views/railsui/themes/corgie/forms/_form_builder.html.erb
@@ -30,13 +30,13 @@
 <%%= form_with model: @user, builder: Railsui::FormBuilder do |f| %>
   <%%= f.text_field :name, label: "Full Name", placeholder: "John Doe" %>
 
-  <%%= f.form_group do %>
+  
     <%%= f.email_field :email, label: "Email Address", placeholder: "john@example.com", help: "We'll never share your email with anyone else." %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.text_area :bio, label: "Biography", placeholder: "Tell us about yourself...", rows: 4 %>
-  <%% end %>
+
 
   <%%= f.submit "Save Profile" %>
 <%% end %>
@@ -120,51 +120,51 @@
   <!-- Text inputs -->
   <%%= f.text_field :text, label: "Text Field" %>
 
-  <%%= f.form_group do %>
+  
     <%%= f.email_field :email, label: "Email Field", placeholder: "john.doe@example.com" %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.password_field :password, label: "Password Field" %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.number_field :number, label: "Number Field", min: 0, max: 100 %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.telephone_field :phone, label: "Phone Number" %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.url_field :website, label: "Website URL" %>
-  <%% end %>
+
 
   <!-- Date/Time inputs -->
-  <%%= f.form_group do %>
+  
     <%%= f.date_field :date, label: "Date" %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.time_field :time, label: "Time" %>
-  <%% end %>
+
 
   <!-- Special inputs -->
-  <%%= f.form_group do %>
+  
     <%%= f.color_field :color, label: "Color Picker" %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.search_field :search, label: "Search", placeholder: "Search..." %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.file_field :file, label: "File Upload" %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.range_field :volume, label: "Volume", min: 0, max: 100, value: 25 %>
-  <%% end %>
+
 <%% end %>
 <% end %>
 <%= render_snippet active_tab: :erb %>
@@ -205,13 +205,13 @@
         { prompt: "Choose a country" },
         { label: "Country" } %>
 
-  <%%= f.form_group do %>
+  
     <%%= f.text_area :message,
           label: "Message",
           placeholder: "Enter your message here...",
           rows: 5,
           help: "Maximum 500 characters" %>
-  <%% end %>
+
 <%% end %>
 <% end %>
 <%= render_snippet active_tab: :erb %>
@@ -347,9 +347,9 @@
   <!-- Switch toggles -->
   <%%= f.switch_field :dark_mode, label: "Enable dark mode" %>
 
-  <%%= f.form_group do %>
+  
     <%%= f.switch_field :auto_save, label: "Auto-save drafts" %>
-  <%% end %>
+
 <%% end %>
 <% end %>
 <%= render_snippet active_tab: :erb %>
@@ -386,9 +386,9 @@
 <%%= form_with model: @user, builder: Railsui::FormBuilder do |f| %>
   <%%= f.text_field :name, label: "Full Name" %>
 
-  <%%= f.form_group do %>
+  
     <%%= f.email_field :email, label: "Email Address" %>
-  <%% end %>
+
 
   <%%= f.submit "Submit" %>
 <%% end %>
@@ -495,22 +495,22 @@
         wrapper: { class: "max-w-md" } %>
 
   <!-- Skip label (i.e. don't display labels) -->
-  <%%= f.form_group do %>
+  
     <%%= f.email_field :email,
           label: false,
           placeholder: "Enter your email",
           help: "Skip displaying label",
           skip_label: true %>
-  <%% end %>
+
 
   <!-- Custom label options and input class -->
-  <%%= f.form_group do %>
+  
     <%%= f.text_field :website,
           label: "Website",
           placeholder: "https://",
           label_options: { class: "form-label font-medium text-sm text-blue-600" },
           class: "form-input text-lg" %>
-  <%% end %>
+
 <%% end %>
 <% end %>
 <%= render_snippet active_tab: :erb %>

--- a/app/views/railsui/themes/hound/forms/_form_builder.html.erb
+++ b/app/views/railsui/themes/hound/forms/_form_builder.html.erb
@@ -30,13 +30,13 @@
 <%%= form_with model: @user, builder: Railsui::FormBuilder do |f| %>
   <%%= f.text_field :name, label: "Full Name", placeholder: "John Doe" %>
 
-  <%%= f.form_group do %>
+  
     <%%= f.email_field :email, label: "Email Address", placeholder: "john@example.com", help: "We'll never share your email with anyone else." %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.text_area :bio, label: "Biography", placeholder: "Tell us about yourself...", rows: 4 %>
-  <%% end %>
+
 
   <%%= f.submit "Save Profile" %>
 <%% end %>
@@ -120,51 +120,51 @@
   <!-- Text inputs -->
   <%%= f.text_field :text, label: "Text Field" %>
 
-  <%%= f.form_group do %>
+  
     <%%= f.email_field :email, label: "Email Field", placeholder: "john.doe@example.com" %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.password_field :password, label: "Password Field" %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.number_field :number, label: "Number Field", min: 0, max: 100 %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.telephone_field :phone, label: "Phone Number" %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.url_field :website, label: "Website URL" %>
-  <%% end %>
+
 
   <!-- Date/Time inputs -->
-  <%%= f.form_group do %>
+  
     <%%= f.date_field :date, label: "Date" %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.time_field :time, label: "Time" %>
-  <%% end %>
+
 
   <!-- Special inputs -->
-  <%%= f.form_group do %>
+  
     <%%= f.color_field :color, label: "Color Picker" %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.search_field :search, label: "Search", placeholder: "Search..." %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.file_field :file, label: "File Upload" %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.range_field :volume, label: "Volume", min: 0, max: 100, value: 25 %>
-  <%% end %>
+
 <%% end %>
 <% end %>
 <%= render_snippet active_tab: :erb %>
@@ -205,13 +205,13 @@
         { prompt: "Choose a country" },
         { label: "Country" } %>
 
-  <%%= f.form_group do %>
+  
     <%%= f.text_area :message,
           label: "Message",
           placeholder: "Enter your message here...",
           rows: 5,
           help: "Maximum 500 characters" %>
-  <%% end %>
+
 <%% end %>
 <% end %>
 <%= render_snippet active_tab: :erb %>
@@ -347,9 +347,9 @@
   <!-- Switch toggles -->
   <%%= f.switch_field :dark_mode, label: "Enable dark mode" %>
 
-  <%%= f.form_group do %>
+  
     <%%= f.switch_field :auto_save, label: "Auto-save drafts" %>
-  <%% end %>
+
 <%% end %>
 <% end %>
 <%= render_snippet active_tab: :erb %>
@@ -386,9 +386,9 @@
 <%%= form_with model: @user, builder: Railsui::FormBuilder do |f| %>
   <%%= f.text_field :name, label: "Full Name" %>
 
-  <%%= f.form_group do %>
+  
     <%%= f.email_field :email, label: "Email Address" %>
-  <%% end %>
+
 
   <%%= f.submit "Submit" %>
 <%% end %>
@@ -495,22 +495,22 @@
         wrapper: { class: "max-w-md" } %>
 
   <!-- Skip label (i.e. don't display labels) -->
-  <%%= f.form_group do %>
+  
     <%%= f.email_field :email,
           label: false,
           placeholder: "Enter your email",
           help: "Skip displaying label",
           skip_label: true %>
-  <%% end %>
+
 
   <!-- Custom label options and input class -->
-  <%%= f.form_group do %>
+  
     <%%= f.text_field :website,
           label: "Website",
           placeholder: "https://",
           label_options: { class: "form-label font-medium text-sm text-blue-600" },
           class: "form-input text-lg" %>
-  <%% end %>
+
 <%% end %>
 <% end %>
 <%= render_snippet active_tab: :erb %>

--- a/app/views/railsui/themes/shepherd/forms/_form_builder.html.erb
+++ b/app/views/railsui/themes/shepherd/forms/_form_builder.html.erb
@@ -30,13 +30,13 @@
 <%%= form_with model: @user, builder: Railsui::FormBuilder do |f| %>
   <%%= f.text_field :name, label: "Full Name", placeholder: "John Doe" %>
 
-  <%%= f.form_group do %>
+  
     <%%= f.email_field :email, label: "Email Address", placeholder: "john@example.com", help: "We'll never share your email with anyone else." %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.text_area :bio, label: "Biography", placeholder: "Tell us about yourself...", rows: 4 %>
-  <%% end %>
+
 
   <%%= f.submit "Save Profile" %>
 <%% end %>
@@ -120,51 +120,51 @@
   <!-- Text inputs -->
   <%%= f.text_field :text, label: "Text Field" %>
 
-  <%%= f.form_group do %>
+  
     <%%= f.email_field :email, label: "Email Field", placeholder: "john.doe@example.com" %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.password_field :password, label: "Password Field" %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.number_field :number, label: "Number Field", min: 0, max: 100 %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.telephone_field :phone, label: "Phone Number" %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.url_field :website, label: "Website URL" %>
-  <%% end %>
+
 
   <!-- Date/Time inputs -->
-  <%%= f.form_group do %>
+  
     <%%= f.date_field :date, label: "Date" %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.time_field :time, label: "Time" %>
-  <%% end %>
+
 
   <!-- Special inputs -->
-  <%%= f.form_group do %>
+  
     <%%= f.color_field :color, label: "Color Picker" %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.search_field :search, label: "Search", placeholder: "Search..." %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.file_field :file, label: "File Upload" %>
-  <%% end %>
 
-  <%%= f.form_group do %>
+
+  
     <%%= f.range_field :volume, label: "Volume", min: 0, max: 100, value: 25 %>
-  <%% end %>
+
 <%% end %>
 <% end %>
 <%= render_snippet active_tab: :erb %>
@@ -205,13 +205,13 @@
         { prompt: "Choose a country" },
         { label: "Country" } %>
 
-  <%%= f.form_group do %>
+  
     <%%= f.text_area :message,
           label: "Message",
           placeholder: "Enter your message here...",
           rows: 5,
           help: "Maximum 500 characters" %>
-  <%% end %>
+
 <%% end %>
 <% end %>
 <%= render_snippet active_tab: :erb %>
@@ -347,9 +347,9 @@
   <!-- Switch toggles -->
   <%%= f.switch_field :dark_mode, label: "Enable dark mode" %>
 
-  <%%= f.form_group do %>
+  
     <%%= f.switch_field :auto_save, label: "Auto-save drafts" %>
-  <%% end %>
+
 <%% end %>
 <% end %>
 <%= render_snippet active_tab: :erb %>
@@ -386,9 +386,9 @@
 <%%= form_with model: @user, builder: Railsui::FormBuilder do |f| %>
   <%%= f.text_field :name, label: "Full Name" %>
 
-  <%%= f.form_group do %>
+  
     <%%= f.email_field :email, label: "Email Address" %>
-  <%% end %>
+
 
   <%%= f.submit "Submit" %>
 <%% end %>
@@ -495,22 +495,22 @@
         wrapper: { class: "max-w-md" } %>
 
   <!-- Skip label (i.e. don't display labels) -->
-  <%%= f.form_group do %>
+  
     <%%= f.email_field :email,
           label: false,
           placeholder: "Enter your email",
           help: "Skip displaying label",
           skip_label: true %>
-  <%% end %>
+
 
   <!-- Custom label options and input class -->
-  <%%= f.form_group do %>
+  
     <%%= f.text_field :website,
           label: "Website",
           placeholder: "https://",
           label_options: { class: "form-label font-medium text-sm text-blue-600" },
           class: "form-input text-lg" %>
-  <%% end %>
+
 <%% end %>
 <% end %>
 <%= render_snippet active_tab: :erb %>


### PR DESCRIPTION
By default, the .form-group class is appended surrounding each helper in the Railsui::FormBuilder. You can override this by setting wrapper: false and passing your own classes if you want. There's no real need to include them in snippet examples.