### PR TITLE
gemspec: reposition summary/description to product UI system

### DIFF
--- a/railsui.gemspec
+++ b/railsui.gemspec
@@ -6,8 +6,8 @@ Gem::Specification.new do |spec|
   spec.version = Railsui::VERSION
   spec.authors = ["Andy Leverenz"]
   spec.email = ["railsui@justalever.com"]
-  spec.summary = "Plug and play UI for Rails"
-  spec.description = "Professionally designed UI components and templates for Ruby on Rails."
+  spec.summary = "The product UI system for Rails SaaS builders"
+  spec.description = "Rails UI is the product UI system for Rails SaaS builders. Complete app kits and the Rails-native components behind them, in clean ERB and Tailwind, so you ship a finished product instead of a blank page."
   spec.homepage = "https://railsui.com"
   spec.metadata = {
     "homepage_uri" => "https://railsui.com",


### PR DESCRIPTION
Updates the RubyGems-facing copy to match the new positioning (the README was already updated in #72).

- `spec.summary`: "Plug and play UI for Rails" -> "The product UI system for Rails SaaS builders"
- `spec.description`: "Professionally designed UI components and templates for Ruby on Rails." -> "Rails UI is the product UI system for Rails SaaS builders. Complete app kits and the Rails-native components behind them, in clean ERB and Tailwind, so you ship a finished product instead of a blank page."

Gemspec still loads (verified). No version change here.

**To release after merging this:** on your machine, from a clean `main`, run `bin/release 3.4.3` (only doc/positioning changes since v3.4.2, so a patch bump). That bumps the version, commits, tags, builds, and `gem push`es to RubyGems with your credentials/MFA.